### PR TITLE
JWW User Story 28

### DIFF
--- a/app/controllers/shelters_controller.rb
+++ b/app/controllers/shelters_controller.rb
@@ -32,7 +32,6 @@ class SheltersController < ApplicationController
     elsif shelter.pets.find_by(status: 'pending')
       flash[:error] = 'Pets Pending for Adoption. Resolve Before Deleting.'
     else
-      shelter.pets.destroy_all
       Shelter.destroy(params[:id])
       flash[:success] = 'Shelter Removed.'
     end

--- a/spec/features/shelter/delete_shelter_and_pets_spec.rb
+++ b/spec/features/shelter/delete_shelter_and_pets_spec.rb
@@ -93,10 +93,15 @@ RSpec.describe 'Shelters with no pending pets', type: :feature do
       visit '/shelters'
 
       expect(current_path).to eq('/shelters')
-      expect(@shelter2.pets.first.name).to eq('Xylia')
+
+      within("p#delete_#{@shelter1.id}") do
+        expect { click_link 'Delete' }.to change(Shelter && Pet, :count).by(0)
+      end
+
+      expect(page).to have_content('Pets Pending for Adoption. Resolve Before Deleting.')
 
       within("p#delete_#{@shelter2.id}") do
-        click_link 'Delete'
+        expect { click_link 'Delete' }.to change(Shelter && Pet, :count).by(-1)
       end
 
       expect(current_path).to eq('/shelters')

--- a/spec/features/shelter/delete_shelter_and_reviews_spec.rb
+++ b/spec/features/shelter/delete_shelter_and_reviews_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe 'When I delete a Shelter', type: :feature do
+  before :each do
+    @shelter1 = Shelter.create(
+      name: "Mike's Shelter",
+      address: '1331 17th Street',
+      city: 'Denver',
+      state: 'CO',
+      zip: '80202'
+    )
+
+    @shelter2 = Shelter.create(
+      name: "Meg's Shelter",
+      address: '150 Main Street',
+      city: 'Hershey',
+      state: 'PA',
+      zip: '17033'
+    )
+
+    @shelter1.reviews.create(
+      title: "A glowing review",
+      rating: "5",
+      content: "Great facility, friendly staff!",
+      image: "https://i.imgur.com/dciDr8Q.jpg"
+    )
+
+    @shelter2.reviews.create(
+      title: "A stellar review",
+      rating: "5",
+      content: "They throw a frisbee with my dog",
+      image: "https://i.imgur.com/dciDr8Q.jpg"
+    )
+  end
+
+  it 'it deletes the reviews for that shelter' do
+
+    visit '/shelters'
+
+    within("p#delete_#{@shelter2.id}") do
+      click_link 'Delete'
+    end
+
+    expect(page).to have_content("Shelter Removed.")
+
+    within("p#delete_#{@shelter1.id}") do
+      click_link 'Delete'
+    end
+
+    expect(page).to have_content("Shelter Removed.")
+    expect(page).to_not have_content("Meg's Shelter")
+    expect(page).to_not have_content("Mike's Shelter")
+  end
+end

--- a/spec/features/shelter/delete_shelter_and_reviews_spec.rb
+++ b/spec/features/shelter/delete_shelter_and_reviews_spec.rb
@@ -18,14 +18,14 @@ RSpec.describe 'When I delete a Shelter', type: :feature do
       zip: '17033'
     )
 
-    @shelter1.reviews.create(
+    @review1 = @shelter1.reviews.create(
       title: "A glowing review",
       rating: "5",
       content: "Great facility, friendly staff!",
       image: "https://i.imgur.com/dciDr8Q.jpg"
     )
 
-    @shelter2.reviews.create(
+    @review2 = @shelter2.reviews.create(
       title: "A stellar review",
       rating: "5",
       content: "They throw a frisbee with my dog",
@@ -34,19 +34,20 @@ RSpec.describe 'When I delete a Shelter', type: :feature do
   end
 
   it 'it deletes the reviews for that shelter' do
-
     visit '/shelters'
 
     within("p#delete_#{@shelter2.id}") do
-      click_link 'Delete'
+      expect { click_link 'Delete' }.to change(Shelter && Review, :count).by(-1)
     end
 
     expect(page).to have_content("Shelter Removed.")
+    expect(current_path).to eq('/shelters')
 
     within("p#delete_#{@shelter1.id}") do
-      click_link 'Delete'
+      expect { click_link 'Delete' }.to change(Shelter && Review, :count).by(-1)
     end
 
+    expect(current_path).to eq('/shelters')
     expect(page).to have_content("Shelter Removed.")
     expect(page).to_not have_content("Meg's Shelter")
     expect(page).to_not have_content("Mike's Shelter")

--- a/spec/features/shelter/shelter_with_pending_pets_cant_delete_spec.rb
+++ b/spec/features/shelter/shelter_with_pending_pets_cant_delete_spec.rb
@@ -90,17 +90,13 @@ RSpec.describe 'Shelters with pets', type: :feature do
 
   describe "pending can't be deleted" do
     it 'when I click delete' do
-      visit "/shelters"
+      visit '/shelters'
 
       within("p#delete_#{@shelter1.id}") do
-        expect(page).to have_link('Delete')
+        expect { click_link 'Delete' }.to change(Shelter && Pet, :count).by(0)
       end
 
-      within("p#delete_#{@shelter1.id}") do
-        click_link 'Delete'
-      end
-
-      expect(page).to have_content("Pets Pending for Adoption. Resolve Before Deleting.")
+      expect(page).to have_content('Pets Pending for Adoption. Resolve Before Deleting.')
     end
   end
 
@@ -109,7 +105,7 @@ RSpec.describe 'Shelters with pets', type: :feature do
       visit "/shelters"
 
       within("p#delete_#{@shelter2.id}") do
-        click_link 'Delete'
+        expect { click_link 'Delete' }.to change(Shelter && Pet, :count).by(-1)
       end
 
       expect(current_path).to eq("/shelters")
@@ -118,11 +114,3 @@ RSpec.describe 'Shelters with pets', type: :feature do
     end
   end
 end
-
-# User Story 27, Shelters can be Deleted as long as all pets do not have approved applications on them
-
-# As a visitor
-# If a shelter doesn't have any pets with a pending status
-# I can delete that shelter
-# When that shelter is deleted
-# Then all of their pets are deleted as well


### PR DESCRIPTION
## User Story 28 | Delete Reviews when Shelter is Deleted

* Relationship is set at the `Shelter` model level with `has_many :reviews, dependent: :destroy` to delete all reviews when a `Shelter` is deleted
* Refactor `shelters_controller` `destroy` action to use the model relationship `  has_many :pets, dependent: :destroy`, which ensures if a shelter passes conditionals to be destroyed it also destroys the associated pets
* The conditionals still check that no pets have a pending application
* I'm trying to find a way to properly test that an active record was destroyed via a `click_link` versus destroying in the test itself. I've been Googling and haven't found a satisfactory answer.
* I have tested with `pry` to ensure all records are being destroyed as expected
* Test coverage is 100% 